### PR TITLE
Improve extract_za_id_dob

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -306,7 +306,16 @@ Extracts the date of birth from a South African identification number
 :param string id: id number
 */
 extract_za_id_dob = function(id) {
-    return moment(id.slice(0,6), 'YYMMDD').format('YYYY-MM-DD');
+    var id_dob = moment(id.slice(0,6), 'YYMMDD').format('YYYY-MM-DD');
+    var dob_century = id_dob.slice(0,2);
+    var dob_two_digit_year = id_dob.slice(2,4);
+
+    // override moment default century switch at '68 with '49
+    if (dob_two_digit_year > 49) {
+        id_dob = id_dob.replace(dob_century, '19');
+    }
+
+    return id_dob;
 };
 
 /**: validate_id_za(id)

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -321,6 +321,10 @@ describe("Testing utils functions", function() {
             // 'Invalid date' when input length < 4
             assert.deepEqual(utils.extract_za_id_dob("810"), "Invalid date");
         });
+        it("", function() {
+            assert.deepEqual(utils.extract_za_id_dob("5202017805280"),
+                moment("1952-02-01").format("YYYY-MM-DD"));
+        });
     });
 
     describe("validate_id_za", function() {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -321,9 +321,24 @@ describe("Testing utils functions", function() {
             // 'Invalid date' when input length < 4
             assert.deepEqual(utils.extract_za_id_dob("810"), "Invalid date");
         });
-        it("", function() {
+        it("correct century extracted", function() {
             assert.deepEqual(utils.extract_za_id_dob("5202017805280"),
                 moment("1952-02-01").format("YYYY-MM-DD"));
+            // boundary case - first day > '49
+            assert.deepEqual(utils.extract_za_id_dob("5001017805280"),
+                moment("1950-01-01").format("YYYY-MM-DD"));
+            // boundary case - last day < '49
+            assert.deepEqual(utils.extract_za_id_dob("4812317805280"),
+                moment("2048-12-31").format("YYYY-MM-DD"));
+            // boundary case (default moment.two_digit_year) - first day > '68
+            assert.deepEqual(utils.extract_za_id_dob("6901017805280"),
+                moment("1969-01-01").format("YYYY-MM-DD"));
+            // boundary case (default moment.two_digit_year) - last day < '68
+            assert.deepEqual(utils.extract_za_id_dob("6712317805280"),
+                moment("1967-12-31").format("YYYY-MM-DD"));
+            // year 2000
+            assert.deepEqual(utils.extract_za_id_dob("0012317805280"),
+                moment("2000-12-31").format("YYYY-MM-DD"));
         });
     });
 


### PR DESCRIPTION
If this extracted part is 540529 for example, then the function returns 2054-05-29 which is wrong by a century.

in old code we did: ```// override moment default century switch at '68 with '49
moment.parseTwoDigitYear = function (input) {
    return +input + (+input > 49 ? 1900 : 2000);
};```