### PR TITLE
Adapt readable_msisdn

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,6 +98,7 @@ Returns msisdn as 'readable' (leading country code effectively replaced with '0'
 :param string country_code: specific country_code to replace
 */
 readable_msisdn = function(msisdn, country_code) {
+    country_code[0] !== '+' ? country_code = '+' + country_code : country_code;
     readable_no = msisdn.replace(country_code, '0');
     return readable_no;
 },

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -72,6 +72,7 @@ describe("Testing utils functions", function() {
             assert.equal(utils.readable_msisdn("+27821234567", "+27"), "0821234567");
             assert.equal(utils.readable_msisdn("+264821234567", "+264"), "0821234567");
             assert.equal(utils.readable_msisdn("0821234567", "+27"), "0821234567");
+            assert.equal(utils.readable_msisdn("+27821234567", "27"), "0821234567");
         });
     });
 


### PR DESCRIPTION
adapt to also accept country code without '+' (e.g. utils.readable_msisdn("0821234567", '27'))