### PR TITLE
Update get_servicerating_status function

### DIFF
--- a/lib/service_rating.js
+++ b/lib/service_rating.js
@@ -10,9 +10,9 @@ function ServiceRating(http_api, auth_token, base_url) {
 ServiceRating.prototype = {
 
     /**:ServiceRating.get_servicerating_status(params)
-    Retrieves service rating status
+    Retrieves service ratings
 
-    :param object params: object containtng parameters
+    :param object params: object containing parameters
       Gets passed through directly to service. Consult service docs/protocol.
       e.g. {
               "identity": identity,

--- a/lib/service_rating.js
+++ b/lib/service_rating.js
@@ -9,21 +9,20 @@ function ServiceRating(http_api, auth_token, base_url) {
 
 ServiceRating.prototype = {
 
-    /**:ServiceRating.get_servicerating_status(identity)
-    Check for service rating status not completed yet
+    /**:ServiceRating.get_servicerating_status(params)
+    Retrieves service rating status
 
-    :param object identity: identity uuid
+    :param object params: object containtng parameters
       Gets passed through directly to service. Consult service docs/protocol.
+      e.g. {
+              "identity": identity,
+              "completed": "False",
+              "expired": "False"
+            }
     */
-    get_servicerating_status: function(identity) {
+    get_servicerating_status: function(params) {
         var endpoint = 'invite/';
         var url = this.base_url + endpoint;
-
-        var params = {
-            "identity": identity,
-            "completed": "False",
-            "expired": "False"
-        };
 
         return this.http_api.get(url, {params: params})
             .then(this.log_service_call('GET', url, params, null))

--- a/lib/service_rating.js
+++ b/lib/service_rating.js
@@ -9,7 +9,7 @@ function ServiceRating(http_api, auth_token, base_url) {
 
 ServiceRating.prototype = {
 
-    /**:ServiceRating.get_servicerating_status(params)
+    /**:ServiceRating.list_serviceratings(params)
     Retrieves service ratings
 
     :param object params: object containing parameters
@@ -20,7 +20,7 @@ ServiceRating.prototype = {
               "expired": "False"
             }
     */
-    get_servicerating_status: function(params) {
+    list_serviceratings: function(params) {
         var endpoint = 'invite/';
         var url = this.base_url + endpoint;
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -842,7 +842,7 @@ module.exports = function() {
             }
         },
 
-        // 25: get identity cb245673-aa41-4302-ac47-00000000001 service rating status
+        // 24: get identity cb245673-aa41-4302-ac47-00000000001 service rating status
         {
             'request': {
                 'method': 'GET',
@@ -874,7 +874,7 @@ module.exports = function() {
             }
         },
 
-        // 26: save servicerating question 1 feedback - cb245673-aa41-4302-ac47-00000000001
+        // 25: save servicerating question 1 feedback - cb245673-aa41-4302-ac47-00000000001
         {
             'request': {
                 'method': 'POST',
@@ -901,7 +901,7 @@ module.exports = function() {
             }
         },
 
-        // 27: patch service rating invite 1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b
+        // 26: patch service rating invite 1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b
         {
             'request': {
                 'method': 'PATCH',
@@ -917,6 +917,36 @@ module.exports = function() {
                 "code": 200,
                 "data": {
                     "success": true
+                }
+            }
+        },
+
+        // 27: get identity cb245673-aa41-4302-ac47-00000000001 service rating status
+        {
+            'request': {
+                'method': 'GET',
+                'params': {
+                    "identity": "cb245673-aa41-4302-ac47-00000000001"
+                },
+                'headers': {
+                    'Authorization': ['Token test_key'],
+                    'Content-Type': ['application/json']
+                },
+                'url': 'http://sr.localhost:8005/api/v1/invite/',
+            },
+            'response': {
+                "code": 200,
+                "data": {
+                    "count": 1,
+                    "next": null,
+                    "previous": null,
+                    "results": [{
+                        "updated_at": "2016-04-04T17:06:08.411867Z",
+                        "created_at": "2016-04-04T17:06:08.411843Z",
+                        "version": 1,
+                        "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                        "identity": "cb245673-aa41-4302-ac47-00000000001",
+                    }]
                 }
             }
         },

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1412,13 +1412,13 @@ describe("Testing app- and service call functions", function() {
     });
 
     describe("SERVICE RATING util functions", function() {
-        describe("Testing get_servicerating_status function - all serviceratings", function() {
+        describe("Testing list_serviceratings function - all serviceratings", function() {
             it("returns all serviceratings for identity", function() {
                 return tester
                     .setup.user.addr('08212345678')
                     .check(function(api) {
                         return sr
-                        .get_servicerating_status({
+                        .list_serviceratings({
                             "identity": "cb245673-aa41-4302-ac47-00000000001"
                         })
                         .then(function(response) {
@@ -1431,13 +1431,13 @@ describe("Testing app- and service call functions", function() {
                     .run();
             });
         });
-        describe("Testing get_servicerating_status function - serviceratings not completed/expired", function() {
+        describe("Testing list_serviceratings function - serviceratings not completed/expired", function() {
             it("returns service ratings not yet completed or not yet expired", function() {
                 return tester
                     .setup.user.addr('08212345678')
                     .check(function(api) {
                         return sr
-                        .get_servicerating_status({
+                        .list_serviceratings({
                             "identity": "cb245673-aa41-4302-ac47-00000000001",
                             "completed": 'False',
                             "expired": 'False'

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1412,15 +1412,39 @@ describe("Testing app- and service call functions", function() {
     });
 
     describe("SERVICE RATING util functions", function() {
-        describe("Testing get_servicerating_status function", function() {
-            it("returns ...", function() {
+        describe("Testing get_servicerating_status function - all serviceratings", function() {
+            it("returns all serviceratings for identity", function() {
                 return tester
                     .setup.user.addr('08212345678')
                     .check(function(api) {
-                        return sr.get_servicerating_status("cb245673-aa41-4302-ac47-00000000001")
-                            .then(function(response) {
-                                assert.equal(response.results[0].identity, "cb245673-aa41-4302-ac47-00000000001");
-                            });
+                        return sr
+                        .get_servicerating_status({
+                            "identity": "cb245673-aa41-4302-ac47-00000000001"
+                        })
+                        .then(function(response) {
+                            assert.equal(response.results[0].identity, "cb245673-aa41-4302-ac47-00000000001");
+                        });
+                    })
+                    .check(function(api) {
+                        utils.check_fixtures_used(api, [27]);
+                    })
+                    .run();
+            });
+        });
+        describe("Testing get_servicerating_status function - serviceratings not completed/expired", function() {
+            it("returns service ratings not yet completed or not yet expired", function() {
+                return tester
+                    .setup.user.addr('08212345678')
+                    .check(function(api) {
+                        return sr
+                        .get_servicerating_status({
+                            "identity": "cb245673-aa41-4302-ac47-00000000001",
+                            "completed": 'False',
+                            "expired": 'False'
+                        })
+                        .then(function(response) {
+                            assert.equal(response.results[0].identity, "cb245673-aa41-4302-ac47-00000000001");
+                        });
                     })
                     .check(function(api) {
                         utils.check_fixtures_used(api, [24]);


### PR DESCRIPTION
Replace current function with:
```
    get_servicerating_status: function(params) {
        var endpoint = 'invite/';
        var url = this.base_url + endpoint;

        return this.http_api.get(url, {params: params})
            .then(this.log_service_call('GET', url, params, null))
            .then(function(response) {
                return response.data;
            });
    },
```