### PR TITLE
Adapt get_today function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -186,10 +186,8 @@ If no date and format is passed in, it will return the current date as a moment 
     e.g. 'YYYY-MM-DD hh:mm:ss', "YYMMDD", etc.  Defaults to 'YYYY-MM-DD'
 */
 get_moment_date = function(date, format) {
-    var date_format = format || 'YYYY-MM-DD';  // if format not specified, assume default
-
     if (date) {
-        return new moment(date, date_format);
+        return new moment(date, format || 'YYYY-MM-DD');
     } else {
         return new moment();
     }

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -19,9 +19,6 @@ var service = require('../lib');
 var utils = require('../lib/utils');
 
 describe("Testing utils functions", function() {
-    var config = {
-        "testing_today": "2016-05-23 12:30:15"
-    };
 
     describe("check_valid_number", function() {
         it("only numbers is valid", function() {
@@ -128,30 +125,30 @@ describe("Testing utils functions", function() {
 
     describe("get_moment_date", function() {
         it("no date passed, return current moment object", function() {
-            assert.deepEqual(utils.get_moment_date().format(), new moment().format());
+            assert.deepEqual(utils.get_moment_date(null, null).format(), new moment().format());
         });
-        it("when date passed in (matching default date format), return corresponding moment object", function() {
-            assert.deepEqual(utils.get_moment_date("1970-08-23").format("YYYY-MM-DD"), "1970-08-23");
+        it("when date passed in that matches default date format, return corresponding moment object", function() {
+            assert.deepEqual(utils.get_moment_date("1970-08-23", null).format("YYYY-MM-DD hh:mm:ss"), "1970-08-23 12:00:00");
         });
-        it("when date passed in (not matching default date format), return corresponding moment object", function() {
-            assert.deepEqual(utils.get_moment_date(config.testing_today).format("YYYY-MM-DD"), "2016-05-23");
+        it("when date passed in that doesn't match default date format, return corresponding moment object", function() {
+            assert.deepEqual(utils.get_moment_date("2016-05-23 12:30:15", null).format("YYYY-MM-DD hh:mm:ss"), "2016-05-23 12:00:00");
         });
-        it("when date & format passed in (date not matching default date format), return corresponding moment object", function() {
-            assert.deepEqual(utils.get_moment_date(config.testing_today, "YYYY-MM-DD").format("YYYY-MM-DD"), "2016-05-23");
+        it("when date & format passed in, return corresponding moment object 1", function() {
+            assert.deepEqual(utils.get_moment_date("2016-05-23 12:30:15", "YYYY-MM-DD").format("YYYY-MM-DD hh:mm:ss"), "2016-05-23 12:00:00");
         });
-        it("when date & format passed in, return corresponding moment object", function() {
-            assert.deepEqual(utils.get_moment_date(config.testing_today, "YYYY-MM-DD hh:mm:ss").format("YYYY-MM-DD hh:mm:ss"),
+        it("when date & format passed in, return corresponding moment object 2", function() {
+            assert.deepEqual(utils.get_moment_date("2016-05-23 12:30:15", "YYYY-MM-DD hh:mm:ss").format("YYYY-MM-DD hh:mm:ss"),
                 "2016-05-23 12:30:15");
         });
         it("when date & format passed in, evaluates to false because of difference in time", function() {
-            assert.notEqual(utils.get_moment_date(config.testing_today, "YYYY-MM-DD hh:mm:ss").format("YYYY-MM-DD hh:mm:ss"),
+            assert.notEqual(utils.get_moment_date("2016-05-23 12:30:15", "YYYY-MM-DD hh:mm:ss").format("YYYY-MM-DD hh:mm:ss"),
                 "2016-05-23 12:30:16");
         });
     });
 
     describe("get_january", function() {
         it("get 1st jan moment date of any given year (test date)", function() {
-            assert.deepEqual(utils.get_january(config.testing_today).format("YYYY-MM-DD"), "2016-01-01");
+            assert.deepEqual(utils.get_january("2016-05-23 12:30:15").format("YYYY-MM-DD"), "2016-01-01");
         });
         it("get 1st jan moment date of current year", function() {
             assert.deepEqual(utils.get_january().format("YYYY-MM-DD"),


### PR DESCRIPTION
pass in `config.testing_today` to a function called `get_moment_date` function, the function should check if a date is passed in and return that date as a moment, otherwise return the current date as a moment
--> so renaming `get_today` to `get_moment_date`