### PR TITLE
Trim message when getting first word

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -310,6 +310,7 @@ Extracts first word from a message.
 */
 get_clean_first_word = function(user_message) {
     return user_message
+        .trim()                 // remove whitespace from start and end
         .split(" ")[0]          // split off first word
         .replace(/\W/g, '')     // remove non letters
         .toUpperCase();         // capitalise

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -309,6 +309,10 @@ describe("Testing utils functions", function() {
             assert.deepEqual(utils.get_clean_first_word("O$ne Two T3ree"), "ONE");
             assert.deepEqual(utils.get_clean_first_word("O$1ne T2wo Th3ree"), "O1NE");
         });
+        it("should get clean first word if starts with whitespace", function() {
+            assert.deepEqual(utils.get_clean_first_word(" Only"), "ONLY");
+            assert.deepEqual(utils.get_clean_first_word("    Once"), "ONCE");
+        });
     });
 
     describe("extract_za_id_dob", function() {


### PR DESCRIPTION
In javascript `' stop'.split(" ")` will evaluate to `['','stop']` So I remove the whitespace around the message content to prevent this.