### PR TITLE
Multi channel support

### DIFF
--- a/lib/message_sender.js
+++ b/lib/message_sender.js
@@ -1,10 +1,11 @@
 var Q = require('q');
 
-function MessageSender(http_api, auth_token, base_url) {
+function MessageSender(http_api, auth_token, base_url, channel) {
     this.http_api = http_api;
     this.auth_token = auth_token;
     this.base_url = base_url;
     this.http_api.defaults.headers.Authorization = ['Token ' + this.auth_token];
+    this.channel = channel;
 }
 
 MessageSender.prototype = {
@@ -61,6 +62,10 @@ MessageSender.prototype = {
             payload.metadata = metadata;
         } else {
             payload.metadata = {};
+        }
+
+        if (this.channel){
+            payload.channel = this.channel;
         }
 
         return this.http_api.post(url, {data: payload})

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -953,5 +953,43 @@ module.exports = function() {
             }
         },
 
+        // 28: create outbound message (different channel)
+        {
+            'request': {
+                'method': 'POST',
+                'params': {},
+                'headers': {
+                    'Authorization': ['Token test Message-sender'],
+                    'Content-Type': ['application/json']
+                },
+                'url': 'http://ms.localhost:8004/api/v1/outbound/',
+                'data': {
+                    "to_addr": "+278212345678",
+                    "identity": "cb245673-aa41-4302-ac47-00000000001",
+                    "content": "testing... testing... 1,2,3",
+                    "metadata": {
+                        "someFlag": true
+                    },
+                    "channel": "CHANNEL"
+                }
+            },
+            'response': {
+                "code": 201,
+                "data": {
+                    'attempts': 0,
+                    'updated_at': '2016-08-18T11:32:17.750207Z',
+                    'content': "testing... testing... 1,2,3",
+                    'created_at': '2016-08-18T11:32:17.750236Z',
+                    'vumi_message_id': '075a32da-e1e4-4424-be46-1d09b71056fd',
+                    'to_addr': "+278212345678",
+                    'metadata': { "someFlag": true },
+                    'id': 'c99bd21e-6b9d-48ba-9f07-1e8e406737fe',
+                    'delivered': "False",
+                    'version': 1,
+                    'url': 'http://ms.localhost:8004/api/v1/outbound/c99bd21e-6b9d-48ba-9f07-1e8e406737fe/'
+                }
+            }
+        },
+
     ];
 };

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -519,6 +519,7 @@ describe("Testing app- and service call functions", function() {
             base_url = app.im.config.services.message_sender.url;
             auth_token = app.im.config.services.message_sender.token;
             ms = new MessageSender(new JsonApi(app.im, null), auth_token, base_url);
+            ms2 = new MessageSender(new JsonApi(app.im, null), auth_token, base_url, "CHANNEL");
 
             base_url = app.im.config.services.service_rating.url;
             auth_token = app.im.config.services.service_rating.token;
@@ -1428,6 +1429,21 @@ describe("Testing app- and service call functions", function() {
                     })
                     .check(function(api) {
                         utils.check_fixtures_used(api, [21]);
+                    })
+                    .run();
+            });
+            it("creates outbound message (diff channel)", function() {
+                return tester
+                    .setup.user.addr('08212345678')
+                    .check(function(api) {
+                        return ms2.create_outbound_message("cb245673-aa41-4302-ac47-00000000001",
+                            "+278212345678", "testing... testing... 1,2,3", { "someFlag": true })
+                            .then(function(outbound_message) {
+                                assert.equal(outbound_message.content, "testing... testing... 1,2,3");
+                            });
+                    })
+                    .check(function(api) {
+                        utils.check_fixtures_used(api, [28]);
                     })
                     .run();
             });


### PR DESCRIPTION
The message sender now allows us to specify which channel we want to send a outbound on. This will add support for this to the jsbox apps.